### PR TITLE
chore: Add CODEOWNERS and enable main branch protection

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Code Owners - all PRs require approval from @rdwj
+*       @rdwj


### PR DESCRIPTION
## Summary

- Adds `.github/CODEOWNERS` requiring `@rdwj` review on all files
- Branch protection rules already configured via GitHub API (PR reviews, CODEOWNERS enforcement, linear history, conversation resolution)

## Test plan

- [ ] Verify CODEOWNERS shows up in repo settings after merge
- [ ] Confirm direct push to main is blocked