### PR TITLE
chore: gitignore .venv/ and NEXT_SESSION.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ MANIFEST
 
 # Virtual environments
 venv/
+.venv/
 env/
 ENV/
 env.bak/
@@ -88,3 +89,6 @@ tokens.txt
 
 # Project specific
 setup_structure.sh
+
+# Session handoff notes (local-only — content lives in MEMORY.md)
+NEXT_SESSION.md


### PR DESCRIPTION
## Summary

Two local-only files that have been showing up untracked across recent sessions:

- `.venv/` — modern uv/python convention. The existing `venv/` entry only caught the older form.
- `NEXT_SESSION.md` — session-handoff notes that live in `~/.claude` memory, not in the repo.

No code changes. Pure hygiene.