### PR TITLE
chore: black format drift + drop "framework" language in docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,7 +141,7 @@ Two cloning strategies exist:
 1. Clone monorepo, extract `templates/agent-loop/` subdirectory
 2. Update `pyproject.toml` name field via tomlkit
 3. String-replace `agent-template` → new name in Chart.yaml, values.yaml, AGENTS.md, Containerfile, Makefile
-4. Source directories are NOT renamed — `base_agent` is a framework component
+4. Source directories are NOT renamed — the agent-loop template ships with `src/agent.py` directly, not a project-named module
 5. Initialize fresh git repository with initial commit
 
 **Rich Console Output**: All user-facing output uses Rich library for:
@@ -272,7 +272,7 @@ def test_something(temp_dir):
 
 **Agent Template** (`fips-agents/agent-template` — monorepo, `templates/agent-loop/`):
 - `pyproject.toml` with project name (no entry point scripts)
-- `src/base_agent/` framework (NOT renamed during customization)
+- `src/agent.py` user agent subclass (lives at this path directly — no project-named module wrapper)
 - `chart/` Helm chart for OpenShift deployment
 - `agent.yaml` configuration (customized via `/plan-agent`, not during scaffolding)
 - `.claude/commands/` with agent development slash commands

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ fips-agents create agent my-agent --github --org fips-agents
 # Non-interactive mode
 fips-agents create agent my-agent --yes --local
 
-# Create with vendored framework source
+# Create with vendored fipsagents source
 fips-agents create agent my-agent --vendored --local
 ```
 
@@ -616,7 +616,7 @@ fips-agents add code-executor
 
 ### Vendor Commands
 
-The `vendor` command copies the fipsagents framework source into your agent project, replacing the PyPI dependency. This gives you full control over the framework code.
+The `vendor` command copies the fipsagents source into your agent project, replacing the PyPI dependency. This gives you full control over the fipsagents code.
 
 #### `vendor`
 
@@ -648,8 +648,8 @@ fips-agents vendor --update
 
 **When to use vendored vs. PyPI:**
 
-- **PyPI dependency** (default): Best for teams running multiple agents that share the same framework version. Centralized updates.
-- **Vendored source**: Best for agents that need custom BaseAgent modifications, environments with no PyPI access, or when you want to read and debug the framework source locally.
+- **PyPI dependency** (default): Best for teams running multiple agents that share the same fipsagents version. Centralized updates.
+- **Vendored source**: Best for agents that need custom BaseAgent modifications, environments with no PyPI access, or when you want to read and debug the fipsagents source locally.
 
 ## Project Name Requirements
 

--- a/src/fips_agents_cli/commands/create.py
+++ b/src/fips_agents_cli/commands/create.py
@@ -507,10 +507,13 @@ def agent(
                 post_clone = None
                 if vendored:
                     from fips_agents_cli.tools.project import vendor_fipsagents_from_clone
+
                     post_clone = vendor_fipsagents_from_clone
 
                 template_commit = clone_template_subdir(
-                    AGENT_TEMPLATE_URL, target_path, AGENT_TEMPLATE_SUBDIR,
+                    AGENT_TEMPLATE_URL,
+                    target_path,
+                    AGENT_TEMPLATE_SUBDIR,
                     post_clone_fn=post_clone,
                 )
             except Exception as e:
@@ -534,6 +537,7 @@ def agent(
                 cleanup_template_files(target_path)
                 if vendored:
                     from fips_agents_cli.tools.project import rewrite_pyproject_for_vendored
+
                     rewrite_pyproject_for_vendored(target_path)
                 if template_commit:
                     write_template_info(

--- a/src/fips_agents_cli/commands/vendor.py
+++ b/src/fips_agents_cli/commands/vendor.py
@@ -67,9 +67,7 @@ def vendor(update: bool, tag: str | None):
 
         if is_already_vendored and not update:
             # Show current version and ask if they want to update
-            console.print(
-                "[yellow]⚠[/yellow] fipsagents is already vendored in this project."
-            )
+            console.print("[yellow]⚠[/yellow] fipsagents is already vendored in this project.")
             console.print(f"  Marker: {vendored_marker}")
             console.print("  Use --update to refresh from upstream.")
             sys.exit(0)
@@ -77,8 +75,7 @@ def vendor(update: bool, tag: str | None):
         # Warn about overwriting local changes
         if update:
             console.print(
-                "\n[yellow]⚠[/yellow] This will overwrite src/fipsagents/ with "
-                "upstream source."
+                "\n[yellow]⚠[/yellow] This will overwrite src/fipsagents/ with " "upstream source."
             )
             console.print(
                 "  Commit any local modifications first to preserve them in git history.\n"

--- a/src/fips_agents_cli/tools/git.py
+++ b/src/fips_agents_cli/tools/git.py
@@ -62,8 +62,12 @@ def clone_template(repo_url: str, target_path: Path, branch: str = "main") -> st
 
 
 def clone_template_subdir(
-    repo_url: str, target_path: Path, subdir: str, branch: str = "main",
-    *, post_clone_fn: callable | None = None,
+    repo_url: str,
+    target_path: Path,
+    subdir: str,
+    branch: str = "main",
+    *,
+    post_clone_fn: callable | None = None,
 ) -> str:
     """
     Clone a monorepo and extract a subdirectory as the project root.

--- a/src/fips_agents_cli/tools/project.py
+++ b/src/fips_agents_cli/tools/project.py
@@ -648,7 +648,7 @@ def rewrite_pyproject_for_vendored(project_path: Path) -> None:
         "httpx",
         "python-frontmatter",
         "fastapi>=0.110",
-        'uvicorn[standard]>=0.27',
+        "uvicorn[standard]>=0.27",
     ]
 
     if "project" in pyproject and "dependencies" in pyproject["project"]:


### PR DESCRIPTION
## Summary

Two unrelated cleanup commits caught by `/session-close`:

1. **`style: Apply black formatting drift fix`** — four source files had drifted from the project's Black config (line length 100). CI's `black --check` step on `test.yml` was failing on `main`. Pure mechanical reformat; no logic changes.
   - `src/fips_agents_cli/commands/create.py`
   - `src/fips_agents_cli/commands/vendor.py`
   - `src/fips_agents_cli/tools/git.py`
   - `src/fips_agents_cli/tools/project.py`

2. **`docs: Drop "framework" language in favor of fipsagents`** — aligns `README.md` and `CLAUDE.md` with the toolkit reframe shipped to fips-agents/examples#25 and fips-agents/agent-template#150. Four lines in README ("vendored framework source", "framework code", "framework version", "framework source locally") rewritten to use "fipsagents" instead. CLAUDE.md additionally fixes two stale `src/base_agent/` references that described a path which never existed in the agent-loop template — the template ships with `src/agent.py` directly.

## Why

fips-agents is a scaffolding toolkit (CLI + composable templates), not a framework. Calling the CLI/ecosystem "the framework" sets the wrong expectation about runtime model. The pieces that *are* framework-shaped (BaseAgent, FastMCP) are inherited or template-internal — fips-agents-cli itself doesn't impose a runtime.

## Test plan

- [x] `black --check src tests` passes (4 files reformatted, 25 unchanged)
- [x] `ruff check src tests` passes
- [x] `pytest` passes (207 passed, 0 failed)
- [x] `gitleaks detect` finds no secrets
- [x] No remaining "framework" hits in `README.md` or `CLAUDE.md` (other than `xml-analysis-framework`, an external project name, which is not present in this repo's docs)