### PR TITLE
chore: black 26 format drift in test fixtures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,15 +28,13 @@ def mock_template_repo(temp_dir):
     template_dir.mkdir()
 
     # Create basic template structure
-    (template_dir / "pyproject.toml").write_text(
-        """[project]
+    (template_dir / "pyproject.toml").write_text("""[project]
 name = "mcp-server-template"
 version = "0.1.0"
 
 [project.scripts]
 mcp-server-template = "mcp_server_template.server:main"
-"""
-    )
+""")
 
     # Create src directory with module
     src_dir = template_dir / "src" / "mcp_server_template"

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -304,12 +304,10 @@ class TestRunComponentTests:
         """Test running tests that pass."""
         # Create a simple passing test
         test_file = tmp_path / "test_example.py"
-        test_file.write_text(
-            """
+        test_file.write_text("""
 def test_passing():
     assert True
-"""
-        )
+""")
 
         success, output = run_component_tests(tmp_path, test_file)
 
@@ -322,12 +320,10 @@ def test_passing():
         """Test running tests that fail."""
         # Create a failing test
         test_file = tmp_path / "test_example.py"
-        test_file.write_text(
-            """
+        test_file.write_text("""
 def test_failing():
     assert False, "This test should fail"
-"""
-        )
+""")
 
         success, output = run_component_tests(tmp_path, test_file)
 


### PR DESCRIPTION
Brings tests/conftest.py and tests/test_generators.py into agreement with black 26.3.1 (the version CI installs given the loose `black>=23.0.0` pin). Unblocks the v0.9.0 release pipeline.