### PR TITLE
chore: Pin black and ruff to current major versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,8 +36,11 @@ dependencies = [
 dev = [
     "pytest>=7.4.0",
     "pytest-cov>=4.1.0",
-    "black>=23.0.0",
-    "ruff>=0.1.0",
+    # Pin formatter/linter major versions so local environments cannot drift
+    # from CI silently. v0.9.0's release was broken by black 24.x vs CI's 26.x
+    # producing different output; v0.9.1 was a same-day patch to recover.
+    "black>=26,<27",
+    "ruff>=0.11,<0.12",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- Pin `black>=26,<27` and `ruff>=0.11,<0.12` in `[project.optional-dependencies].dev`
- Prevents local environments from silently drifting past CI's formatter/linter major versions

## Why
v0.9.0's release pipeline failed because a local `black 24.x` install produced different formatting than CI's `26.x`. v0.9.1 was a same-day recovery patch (PRs #34, #35). The loose `black>=23.0.0` floor made that possible. With major-version caps a fresh `pip install -e '.[dev]'` matches CI, and crossing a major becomes a deliberate change.

## Test plan
- [x] `black --check src tests` — clean
- [x] `ruff check src tests` — clean
- [x] `pytest -q` — 231 passed
- [ ] CI green on PR