### PR TITLE
feat: Add ModalitySpec helper for composable agent capabilities

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "gitpython>=3.1.0",
     "tomlkit>=0.12.0",
     "jinja2>=3.1.2",
+    "ruamel.yaml>=0.18,<0.19",
 ]
 
 [project.optional-dependencies]

--- a/src/fips_agents_cli/commands/add.py
+++ b/src/fips_agents_cli/commands/add.py
@@ -7,7 +7,17 @@ import click
 from rich.console import Console
 from rich.panel import Panel
 
+from fips_agents_cli.tools.modality import (
+    ModalityError,
+    ModalityResult,
+    ModalitySpec,
+    SourceFile,
+    apply_modality,
+)
+from fips_agents_cli.tools.project import find_agent_project_root
+
 console = Console()
+
 
 # The code_executor tool source, embedded directly to avoid network dependencies.
 # Source: agent-template/examples/code-sandbox-agent/tools/code_executor.py
@@ -83,13 +93,76 @@ async def code_executor(code: str, timeout: float = 10.0) -> str:
 '''
 
 
-def _find_agent_project_root() -> Path | None:
-    """Find the agent project root by looking for agent.yaml."""
-    current = Path.cwd()
-    for parent in [current] + list(current.parents):
-        if (parent / "agent.yaml").exists():
-            return parent
-    return None
+CODE_EXECUTOR_NEXT_STEPS = (
+    "1. Build or deploy the sandbox sidecar:",
+    "   [dim]fips-agents create sandbox my-sandbox[/dim]",
+    "   or use the pre-built image from fips-agents/code-sandbox",
+    "",
+    "2. Configure the sandbox URL for your agent:",
+    "",
+    "   [bold]Sidecar mode[/bold] (same pod, default):",
+    "     The tool defaults to http://localhost:8000",
+    "     No extra config needed if sandbox runs as a sidecar container.",
+    "",
+    "   [bold]Remote service mode[/bold] (separate deployment):",
+    "     Set the SANDBOX_URL environment variable:",
+    "     [dim]export SANDBOX_URL=http://sandbox-service:8000[/dim]",
+    "",
+    "3. The agent will auto-discover tools/code_executor.py.",
+    "   Use it in your agent's step() by calling:",
+    '     [dim]await self.use_tool("code_executor", code="print(1+1)")[/dim]',
+)
+
+
+CODE_EXECUTOR_SPEC = ModalitySpec(
+    name="code-executor",
+    description="Sandbox code execution",
+    chart_values_enable="sandbox.enabled",
+    source_files=(
+        SourceFile(
+            relative_path="tools/code_executor.py",
+            content=CODE_EXECUTOR_TOOL_SOURCE,
+        ),
+    ),
+    next_steps=CODE_EXECUTOR_NEXT_STEPS,
+)
+
+
+def _print_modality_result(spec: ModalitySpec, result: ModalityResult) -> None:
+    """Render the per-action lines + the success panel for an applied spec."""
+    for action in result.actions:
+        console.print(f"[green]+[/green] {action}")
+    for skipped in result.skipped:
+        console.print(f"[dim]{skipped}[/dim]")
+    for warning in result.warnings:
+        console.print(f"[yellow]Warning:[/yellow] {warning}")
+
+    body_lines = [f"[bold green]{spec.description} added.[/bold green]", ""]
+    if spec.next_steps:
+        body_lines.append("[bold cyan]Next Steps:[/bold cyan]")
+        body_lines.append("")
+        body_lines.extend(f"  {line}" for line in spec.next_steps)
+
+    console.print(
+        Panel(
+            "\n".join(body_lines),
+            border_style="green",
+            padding=(1, 2),
+        )
+    )
+
+
+def _resolve_agent_project_or_exit() -> Path:
+    project_root = find_agent_project_root()
+    if project_root is None:
+        console.print(
+            "[red]Error:[/red] Not in an agent project directory.\n"
+            "Could not find agent.yaml or .template-info in this directory or any parent.\n\n"
+            "[yellow]Hint:[/yellow] Run this command from an agent project "
+            "created with [dim]fips-agents create agent[/dim]."
+        )
+        sys.exit(1)
+    return project_root
 
 
 @click.group()
@@ -112,96 +185,16 @@ def code_executor_cmd():
         fips-agents add code-executor
     """
     try:
-        # Step 1: Detect project root
-        project_root = _find_agent_project_root()
-        if project_root is None:
-            console.print(
-                "[red]Error:[/red] Not in an agent project directory.\n"
-                "Could not find agent.yaml in this directory or any parent.\n\n"
-                "[yellow]Hint:[/yellow] Run this command from an agent project "
-                "created with [dim]fips-agents create agent[/dim]."
-            )
-            sys.exit(1)
-
+        project_root = _resolve_agent_project_or_exit()
         console.print(f"[green]Found project root:[/green] {project_root}")
 
-        # Step 2: Check tools/ directory exists
-        tools_dir = project_root / "tools"
-        if not tools_dir.exists():
-            console.print(
-                "[red]Error:[/red] No tools/ directory found in project root.\n\n"
-                "[yellow]Hint:[/yellow] Create it with: [dim]mkdir tools[/dim]"
-            )
+        try:
+            result = apply_modality(project_root, CODE_EXECUTOR_SPEC)
+        except ModalityError as e:
+            console.print(f"\n[red]Error:[/red] {e}")
             sys.exit(1)
 
-        # Step 3: Write the tool file
-        tool_file = tools_dir / "code_executor.py"
-        if tool_file.exists():
-            console.print(
-                "[yellow]Warning:[/yellow] tools/code_executor.py already exists. Skipping."
-            )
-        else:
-            tool_file.write_text(CODE_EXECUTOR_TOOL_SOURCE)
-            console.print("[green]+[/green] Created tools/code_executor.py")
-
-        # Step 4: Update chart/values.yaml if present
-        values_file = project_root / "chart" / "values.yaml"
-        if values_file.exists():
-            values_content = values_file.read_text()
-            if "sandbox:" in values_content:
-                if "enabled: false" in values_content:
-                    values_content = values_content.replace("enabled: false", "enabled: true", 1)
-                    values_file.write_text(values_content)
-                    console.print("[green]+[/green] Set sandbox.enabled: true in chart/values.yaml")
-                elif "enabled: true" in values_content:
-                    console.print("[dim]sandbox.enabled already true in chart/values.yaml[/dim]")
-                else:
-                    console.print(
-                        "[yellow]Warning:[/yellow] Found sandbox: section in "
-                        "chart/values.yaml but could not locate enabled field. "
-                        "Please set sandbox.enabled: true manually."
-                    )
-            else:
-                console.print(
-                    "[yellow]Warning:[/yellow] No sandbox: section in chart/values.yaml.\n"
-                    "  Add the following to your values.yaml:\n"
-                    "  [dim]sandbox:\n"
-                    "    enabled: true\n"
-                    "    image: <your-sandbox-image>[/dim]"
-                )
-        else:
-            console.print("[dim]No chart/values.yaml found (not using Helm chart). Skipping.[/dim]")
-
-        # Step 5: Success panel
-        next_steps = """
-[bold cyan]Next Steps:[/bold cyan]
-
-  1. Build or deploy the sandbox sidecar:
-     [dim]fips-agents create sandbox my-sandbox[/dim]
-     or use the pre-built image from fips-agents/code-sandbox
-
-  2. Configure the sandbox URL for your agent:
-
-     [bold]Sidecar mode[/bold] (same pod, default):
-       The tool defaults to http://localhost:8000
-       No extra config needed if sandbox runs as a sidecar container.
-
-     [bold]Remote service mode[/bold] (separate deployment):
-       Set the SANDBOX_URL environment variable:
-       [dim]export SANDBOX_URL=http://sandbox-service:8000[/dim]
-
-  3. The agent will auto-discover tools/code_executor.py.
-     Use it in your agent's step() by calling:
-       [dim]await self.use_tool("code_executor", code="print(1+1)")[/dim]
-"""
-
-        console.print(
-            Panel(
-                f"[bold green]Code executor tool added.[/bold green]\n{next_steps}",
-                border_style="green",
-                padding=(1, 2),
-            )
-        )
+        _print_modality_result(CODE_EXECUTOR_SPEC, result)
 
     except KeyboardInterrupt:
         console.print("\n[yellow]Operation cancelled.[/yellow]")

--- a/src/fips_agents_cli/tools/modality.py
+++ b/src/fips_agents_cli/tools/modality.py
@@ -1,0 +1,285 @@
+"""Apply composable capabilities ("modalities") to existing agent projects.
+
+A *modality* is a capability that the user opts into after their agent
+project has already been scaffolded — file uploads, vision input, voice,
+video, sandbox code execution, and so on. The agent template ships every
+modality in a disabled state (``enabled: false`` in ``agent.yaml`` and
+``chart/values.yaml``) plus any sidecar templates guarded by Helm
+conditionals. The CLI's job is to flip those toggles atomically and drop
+in any source-file scaffolds the modality needs.
+
+This module models a modality declaratively as a :class:`ModalitySpec`.
+:func:`apply_modality` walks the spec and applies every change
+idempotently. New ``add`` subcommands should be a few lines of glue
+around a spec and a single :func:`apply_modality` call — no more
+hand-written string replacement, which is what motivated this module
+(see ``commands/add.py``'s pre-refactor ``code-executor`` for the
+pattern we are replacing).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import tomlkit
+from ruamel.yaml import YAML
+from ruamel.yaml.comments import CommentedMap
+
+
+class ModalityError(Exception):
+    """Raised when a modality cannot be applied to a project."""
+
+
+@dataclass(frozen=True)
+class SourceFile:
+    """A source file the modality drops into the project tree.
+
+    Attributes:
+        relative_path: Path relative to the project root (POSIX style).
+        content: Full file content to write.
+        skip_if_exists: When true (the default), an existing file at the
+            target path is left untouched and the action is recorded as
+            "skipped". When false, the file is overwritten.
+    """
+
+    relative_path: str
+    content: str
+    skip_if_exists: bool = True
+
+
+@dataclass(frozen=True)
+class PyprojectExtra:
+    """An optional-dependencies extra to add to ``pyproject.toml``.
+
+    Attributes:
+        name: Extra name, e.g. ``"files"``. Becomes a key under
+            ``[project.optional-dependencies]``.
+        dependencies: Requirement strings, e.g.
+            ``["docling>=2.0", "boto3>=1.34"]``.
+    """
+
+    name: str
+    dependencies: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ModalitySpec:
+    """Declarative description of a modality the user can ``add``.
+
+    Every field except ``name`` and ``description`` is optional — a
+    modality may need only a chart toggle (e.g. ``code-executor``), only
+    a source-file drop, or any combination. ``apply_modality`` only
+    touches the files the spec actually references.
+    """
+
+    name: str
+    description: str
+
+    #: Dotted key path inside ``agent.yaml`` whose value should be set
+    #: to ``True``. For example ``"server.files.enabled"`` flips the
+    #: ``files.enabled`` field nested under the ``server`` block.
+    agent_yaml_enable: str | None = None
+
+    #: Dotted key path inside ``chart/values.yaml`` whose value should be
+    #: set to ``True``. For example ``"sandbox.enabled"`` or
+    #: ``"files.enabled"``.
+    chart_values_enable: str | None = None
+
+    #: Source files to write into the project.
+    source_files: tuple[SourceFile, ...] = ()
+
+    #: Optional extra to register under ``[project.optional-dependencies]``.
+    pyproject_extra: PyprojectExtra | None = None
+
+    #: Cross-modality precondition. Receives the project root and returns
+    #: ``(ok, message)``. When ``ok`` is false, ``apply_modality`` raises
+    #: :class:`ModalityError` with ``message`` and makes no changes.
+    precondition: Callable[[Path], tuple[bool, str]] | None = None
+
+    #: Plain-text follow-up steps printed by the calling command after a
+    #: successful apply. Each entry is rendered as a separate line.
+    next_steps: tuple[str, ...] = ()
+
+
+@dataclass
+class ModalityResult:
+    """Outcome of an :func:`apply_modality` call.
+
+    The result is informational — :func:`apply_modality` raises on
+    unrecoverable errors. Anything in ``warnings`` is non-fatal: the
+    modality is partially applied and the user should be told.
+    """
+
+    actions: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    skipped: list[str] = field(default_factory=list)
+
+
+def apply_modality(project_root: Path, spec: ModalitySpec) -> ModalityResult:
+    """Apply ``spec`` to the agent project rooted at ``project_root``.
+
+    The function is idempotent: running it twice is a no-op the second
+    time (every step is a "skipped" entry in the result). Unrecoverable
+    errors (precondition failure, malformed YAML, missing target file
+    that the spec strictly requires) raise :class:`ModalityError`.
+    Recoverable surprises (target section missing, key not present)
+    surface as warnings and the rest of the spec still applies.
+
+    Args:
+        project_root: Path to the agent project root.
+        spec: The modality to apply.
+
+    Returns:
+        :class:`ModalityResult` describing every action taken.
+    """
+    if not project_root.is_dir():
+        raise ModalityError(f"Project root does not exist: {project_root}")
+
+    if spec.precondition is not None:
+        ok, message = spec.precondition(project_root)
+        if not ok:
+            raise ModalityError(message)
+
+    result = ModalityResult()
+
+    for source in spec.source_files:
+        _apply_source_file(project_root, source, result)
+
+    if spec.agent_yaml_enable is not None:
+        _toggle_yaml_key(
+            project_root / "agent.yaml",
+            spec.agent_yaml_enable,
+            result,
+            file_label="agent.yaml",
+        )
+
+    if spec.chart_values_enable is not None:
+        _toggle_yaml_key(
+            project_root / "chart" / "values.yaml",
+            spec.chart_values_enable,
+            result,
+            file_label="chart/values.yaml",
+        )
+
+    if spec.pyproject_extra is not None:
+        _add_pyproject_extra(project_root / "pyproject.toml", spec.pyproject_extra, result)
+
+    return result
+
+
+def _apply_source_file(project_root: Path, source: SourceFile, result: ModalityResult) -> None:
+    target = project_root / source.relative_path
+    if target.exists() and source.skip_if_exists:
+        result.skipped.append(f"{source.relative_path} already exists")
+        return
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(source.content)
+    result.actions.append(f"Wrote {source.relative_path}")
+
+
+def _toggle_yaml_key(
+    yaml_path: Path,
+    dotted_key: str,
+    result: ModalityResult,
+    *,
+    file_label: str,
+) -> None:
+    """Set ``dotted_key`` to ``True`` in the YAML file at ``yaml_path``.
+
+    Uses ruamel.yaml in round-trip mode so existing comments, key order,
+    and string-quoting style are preserved. Missing files / missing
+    intermediate keys produce warnings instead of errors so the rest of
+    the modality can still apply (e.g. a project without a Helm chart
+    can still get its tool source files dropped in).
+    """
+    if not yaml_path.exists():
+        result.warnings.append(f"No {file_label} found — skipped {dotted_key} toggle")
+        return
+
+    yaml = YAML()
+    yaml.preserve_quotes = True
+    try:
+        with open(yaml_path) as f:
+            data = yaml.load(f)
+    except Exception as e:
+        raise ModalityError(f"Failed to parse {file_label}: {e}") from e
+
+    if not isinstance(data, CommentedMap):
+        raise ModalityError(f"{file_label} root is not a mapping")
+
+    parts = dotted_key.split(".")
+    cursor: CommentedMap = data
+    for part in parts[:-1]:
+        if not isinstance(cursor, CommentedMap) or part not in cursor:
+            result.warnings.append(
+                f"{file_label} has no '{'.'.join(parts[: parts.index(part) + 1])}' "
+                f"section — set {dotted_key}: true manually"
+            )
+            return
+        cursor = cursor[part]
+
+    leaf = parts[-1]
+    if not isinstance(cursor, CommentedMap) or leaf not in cursor:
+        result.warnings.append(
+            f"{file_label} has no '{dotted_key}' field — set it to true manually"
+        )
+        return
+
+    current = cursor[leaf]
+    if current is True:
+        result.skipped.append(f"{dotted_key} already true in {file_label}")
+        return
+
+    cursor[leaf] = True
+    try:
+        with open(yaml_path, "w") as f:
+            yaml.dump(data, f)
+    except Exception as e:
+        raise ModalityError(f"Failed to write {file_label}: {e}") from e
+
+    result.actions.append(f"Set {dotted_key}: true in {file_label}")
+
+
+def _add_pyproject_extra(
+    pyproject_path: Path, extra: PyprojectExtra, result: ModalityResult
+) -> None:
+    """Register ``extra`` under ``[project.optional-dependencies]``.
+
+    Merges with an existing extra of the same name (deduplicating by
+    requirement string). tomlkit preserves comments and formatting in
+    ``pyproject.toml``, matching the rest of the codebase's TOML edits.
+    """
+    if not pyproject_path.exists():
+        result.warnings.append(
+            f"No pyproject.toml found — declare the [{extra.name}] extra manually"
+        )
+        return
+
+    try:
+        doc = tomlkit.parse(pyproject_path.read_text())
+    except Exception as e:
+        raise ModalityError(f"Failed to parse pyproject.toml: {e}") from e
+
+    project = doc.setdefault("project", tomlkit.table())
+    optional = project.setdefault("optional-dependencies", tomlkit.table())
+
+    if extra.name in optional:
+        existing = list(optional[extra.name])
+        before = len(existing)
+        for dep in extra.dependencies:
+            if dep not in existing:
+                existing.append(dep)
+        if len(existing) == before:
+            result.skipped.append(f"[{extra.name}] extra already declares all deps")
+            return
+        optional[extra.name] = existing
+        action = f"Updated [{extra.name}] extra in pyproject.toml"
+    else:
+        optional[extra.name] = list(extra.dependencies)
+        action = f"Added [{extra.name}] extra to pyproject.toml"
+
+    pyproject_path.write_text(tomlkit.dumps(doc))
+    result.actions.append(action)

--- a/src/fips_agents_cli/tools/project.py
+++ b/src/fips_agents_cli/tools/project.py
@@ -493,6 +493,50 @@ def customize_go_project(project_path: Path, new_name: str, sentinel: str) -> No
         raise
 
 
+def find_agent_project_root(start: Path | None = None) -> Path | None:
+    """Walk up from ``start`` to locate an agent project root.
+
+    Recognizes a directory as an agent project root when either is true:
+      - It carries a ``.template-info`` file whose ``template.type`` is
+        ``"agent"`` (preferred — this is what ``fips-agents create agent``
+        writes since v0.8.x).
+      - It contains an ``agent.yaml`` (legacy projects scaffolded before
+        ``.template-info`` carried ``template.type``, plus hand-rolled
+        agent projects that follow the template layout).
+
+    The dual check matches the contract of the existing ``add code-executor``
+    command (which only looked for ``agent.yaml``) while letting newer
+    callers prefer the explicit ``.template-info`` signal.
+
+    Args:
+        start: Directory to begin walking from. Defaults to ``Path.cwd()``.
+
+    Returns:
+        Path to the agent project root, or ``None`` if no agent project is
+        found in ``start`` or any of its parents.
+    """
+    cwd = start or Path.cwd()
+    for parent in [cwd] + list(cwd.parents):
+        info_file = parent / ".template-info"
+        if info_file.exists():
+            try:
+                with open(info_file) as f:
+                    template_info = json.load(f)
+                ptype = template_info.get("template", {}).get("type", "mcp-server")
+                if ptype == "agent":
+                    return parent
+                # Wrong project type at this level — keep walking. A user could
+                # be inside a subdir (e.g. examples/) of a non-agent project
+                # that itself contains an agent project elsewhere upstream.
+                continue
+            except Exception:
+                # Fall through to the agent.yaml legacy check below.
+                pass
+        if (parent / "agent.yaml").exists():
+            return parent
+    return None
+
+
 def cleanup_template_files(project_path: Path) -> None:
     """
     Remove template-specific files that shouldn't be in the new project.

--- a/tests/fixtures/agent_project/.template-info
+++ b/tests/fixtures/agent_project/.template-info
@@ -1,0 +1,13 @@
+{
+  "template": {
+    "type": "agent",
+    "url": "https://github.com/fips-agents/agent-template",
+    "subdir": "templates/agent-loop",
+    "commit": "fixture"
+  },
+  "project": {
+    "name": "fixture-agent"
+  },
+  "generated_at": "2026-05-04T00:00:00Z",
+  "fips_agents_cli_version": "fixture"
+}

--- a/tests/fixtures/agent_project/agent.yaml
+++ b/tests/fixtures/agent_project/agent.yaml
@@ -1,0 +1,40 @@
+# agent.yaml — fixture mirroring a subset of agent-template/agent-loop.
+#
+# This is intentionally a small structural snapshot, not a full copy. It
+# carries enough of the real template's shape (nested `server.files`,
+# top-level `memory`, env-var substitution, comments) for tests of the
+# modality helper to exercise YAML round-tripping and dotted-key toggles.
+# Keep this in sync with the live template when adding fields the helper
+# tests need to touch.
+
+agent:
+  name: ${AGENT_NAME:-fixture-agent}
+  description: "Fixture agent for tests"
+  version: 0.1.0
+
+model:
+  provider: ${MODEL_PROVIDER:-openai}
+  endpoint: ${MODEL_ENDPOINT:-http://llamastack:8321/v1}
+  name: ${MODEL_NAME:-meta-llama/Llama-3.3-70B-Instruct}
+
+server:
+  host: ${HOST:-0.0.0.0}
+  port: ${PORT:-8080}
+
+  # -- File uploads (optional) ------------------------------------------------
+  # Disabled by default. Flip enabled via `fips-agents add files`.
+  files:
+    enabled: ${FILES_ENABLED:-false}
+    backend: ${FILES_BACKEND:-}
+    max_file_size_bytes: ${FILES_MAX_SIZE_BYTES:-52428800}
+
+  # -- Trace collection (optional) ---------------------------------------------
+  traces:
+    enabled: ${TRACES_ENABLED:-false}
+    sampling_rate: 1.0
+
+memory:
+  backend: ${MEMORY_BACKEND:-}
+
+logging:
+  level: ${LOG_LEVEL:-INFO}

--- a/tests/fixtures/agent_project/chart/values.yaml
+++ b/tests/fixtures/agent_project/chart/values.yaml
@@ -1,0 +1,32 @@
+# Default values for fixture agent — mirrors a subset of agent-template's
+# Helm values.yaml shape. Carries the modality toggles that the helper's
+# tests need to flip (sandbox, files) plus an unrelated section so tests
+# can verify the helper does not touch fields it shouldn't.
+
+replicaCount: 1
+
+image:
+  repository: agent-template
+  tag: latest
+  pullPolicy: IfNotPresent
+
+# -- Code execution sandbox sidecar (optional) --------------------------------
+# Toggled by `fips-agents add code-executor`.
+sandbox:
+  enabled: false
+  profile: minimal
+  image:
+    repository: code-sandbox
+    tag: latest
+
+# -- File uploads + ClamAV sidecar (optional) ---------------------------------
+# Toggled by `fips-agents add files`.
+files:
+  enabled: false
+  backend: ""
+  persistence:
+    enabled: false
+    size: 5Gi
+  virusScanner:
+    enabled: false
+    failMode: open

--- a/tests/fixtures/agent_project/pyproject.toml
+++ b/tests/fixtures/agent_project/pyproject.toml
@@ -1,0 +1,17 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "fixture-agent"
+version = "0.1.0"
+description = "Fixture agent project for tests"
+requires-python = ">=3.10"
+dependencies = [
+    "fipsagents>=0.19",
+]
+
+[project.optional-dependencies]
+metrics = [
+    "prometheus-client>=0.20",
+]

--- a/tests/fixtures/agent_project/src/agent.py
+++ b/tests/fixtures/agent_project/src/agent.py
@@ -1,0 +1,1 @@
+"""Placeholder agent module — fixture content only."""

--- a/tests/test_modality.py
+++ b/tests/test_modality.py
@@ -1,0 +1,369 @@
+"""Tests for the modality helper used by `fips-agents add` subcommands."""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+from ruamel.yaml import YAML
+
+from fips_agents_cli.cli import cli
+from fips_agents_cli.commands.add import CODE_EXECUTOR_SPEC
+from fips_agents_cli.tools.modality import (
+    ModalityError,
+    ModalitySpec,
+    PyprojectExtra,
+    SourceFile,
+    apply_modality,
+)
+from fips_agents_cli.tools.project import find_agent_project_root
+
+FIXTURE_SOURCE = Path(__file__).parent / "fixtures" / "agent_project"
+
+
+@pytest.fixture
+def agent_project(tmp_path: Path) -> Path:
+    """Copy the committed agent fixture into a tmp dir for safe mutation."""
+    dest = tmp_path / "myagent"
+    shutil.copytree(FIXTURE_SOURCE, dest)
+    return dest
+
+
+def _yaml_load(path: Path):
+    yaml = YAML()
+    with open(path) as f:
+        return yaml.load(f)
+
+
+# ---------------------------------------------------------------------------
+# find_agent_project_root
+# ---------------------------------------------------------------------------
+
+
+class TestFindAgentProjectRoot:
+    def test_finds_via_template_info(self, agent_project: Path) -> None:
+        nested = agent_project / "tools"
+        nested.mkdir(exist_ok=True)
+        assert find_agent_project_root(start=nested) == agent_project
+
+    def test_finds_via_agent_yaml_when_no_template_info(self, agent_project: Path) -> None:
+        (agent_project / ".template-info").unlink()
+        assert find_agent_project_root(start=agent_project) == agent_project
+
+    def test_returns_none_outside_a_project(self, tmp_path: Path) -> None:
+        assert find_agent_project_root(start=tmp_path) is None
+
+    def test_skips_non_agent_template_info(self, tmp_path: Path) -> None:
+        # An mcp-server project should NOT be returned as an agent project,
+        # even if its .template-info is found while walking up.
+        (tmp_path / ".template-info").write_text('{"template": {"type": "mcp-server"}}')
+        assert find_agent_project_root(start=tmp_path) is None
+
+
+# ---------------------------------------------------------------------------
+# apply_modality — chart/values.yaml toggle
+# ---------------------------------------------------------------------------
+
+
+class TestChartValuesToggle:
+    def test_flips_top_level_enabled_field(self, agent_project: Path) -> None:
+        spec = ModalitySpec(
+            name="sandbox",
+            description="Sandbox sidecar",
+            chart_values_enable="sandbox.enabled",
+        )
+        result = apply_modality(agent_project, spec)
+        assert "Set sandbox.enabled: true in chart/values.yaml" in result.actions
+
+        values = _yaml_load(agent_project / "chart" / "values.yaml")
+        assert values["sandbox"]["enabled"] is True
+        # Sibling fields untouched
+        assert values["sandbox"]["profile"] == "minimal"
+        assert values["replicaCount"] == 1
+
+    def test_flips_nested_persistence_enabled(self, agent_project: Path) -> None:
+        spec = ModalitySpec(
+            name="files-persist",
+            description="Files persistence",
+            chart_values_enable="files.persistence.enabled",
+        )
+        apply_modality(agent_project, spec)
+        values = _yaml_load(agent_project / "chart" / "values.yaml")
+        assert values["files"]["persistence"]["enabled"] is True
+        assert values["files"]["enabled"] is False  # untouched
+
+    def test_idempotent_on_already_true_value(self, agent_project: Path) -> None:
+        # Pre-flip the value, then run apply twice — second pass should
+        # report skipped, not re-write.
+        values_path = agent_project / "chart" / "values.yaml"
+        text = values_path.read_text().replace(
+            "sandbox:\n  enabled: false", "sandbox:\n  enabled: true", 1
+        )
+        values_path.write_text(text)
+
+        spec = ModalitySpec(
+            name="sandbox",
+            description="Sandbox sidecar",
+            chart_values_enable="sandbox.enabled",
+        )
+        result = apply_modality(agent_project, spec)
+        assert any("already true" in s for s in result.skipped)
+        assert result.actions == []
+
+    def test_warns_on_missing_section(self, agent_project: Path) -> None:
+        spec = ModalitySpec(
+            name="bogus",
+            description="Bogus",
+            chart_values_enable="nonexistent.enabled",
+        )
+        result = apply_modality(agent_project, spec)
+        assert any("nonexistent" in w for w in result.warnings)
+        assert result.actions == []
+
+    def test_warns_on_missing_values_yaml(self, agent_project: Path) -> None:
+        (agent_project / "chart" / "values.yaml").unlink()
+        spec = ModalitySpec(
+            name="sandbox",
+            description="Sandbox sidecar",
+            chart_values_enable="sandbox.enabled",
+        )
+        result = apply_modality(agent_project, spec)
+        assert any("chart/values.yaml" in w for w in result.warnings)
+
+
+# ---------------------------------------------------------------------------
+# apply_modality — agent.yaml toggle
+# ---------------------------------------------------------------------------
+
+
+class TestAgentYamlToggle:
+    def test_flips_nested_server_files_enabled(self, agent_project: Path) -> None:
+        spec = ModalitySpec(
+            name="files",
+            description="File uploads",
+            agent_yaml_enable="server.files.enabled",
+        )
+        result = apply_modality(agent_project, spec)
+        assert any("server.files.enabled: true in agent.yaml" in a for a in result.actions)
+
+        loaded = _yaml_load(agent_project / "agent.yaml")
+        assert loaded["server"]["files"]["enabled"] is True
+        # Sibling untouched
+        assert (
+            loaded["server"]["files"]["max_file_size_bytes"] == "${FILES_MAX_SIZE_BYTES:-52428800}"
+        )
+        assert loaded["server"]["traces"]["enabled"] == "${TRACES_ENABLED:-false}"
+
+    def test_preserves_comments_and_env_var_substitutions(self, agent_project: Path) -> None:
+        spec = ModalitySpec(
+            name="files",
+            description="File uploads",
+            agent_yaml_enable="server.files.enabled",
+        )
+        apply_modality(agent_project, spec)
+
+        text = (agent_project / "agent.yaml").read_text()
+        # Comments preserved
+        assert "# -- File uploads (optional)" in text
+        # Unrelated env-var substitutions preserved verbatim
+        assert "${MODEL_NAME:-meta-llama/Llama-3.3-70B-Instruct}" in text
+        assert "${TRACES_ENABLED:-false}" in text
+
+
+# ---------------------------------------------------------------------------
+# apply_modality — source files
+# ---------------------------------------------------------------------------
+
+
+class TestSourceFiles:
+    def test_writes_new_file(self, agent_project: Path) -> None:
+        spec = ModalitySpec(
+            name="vision",
+            description="Vision",
+            source_files=(SourceFile("tools/vision_helper.py", "# vision helper\n"),),
+        )
+        result = apply_modality(agent_project, spec)
+        assert "Wrote tools/vision_helper.py" in result.actions
+        assert (agent_project / "tools" / "vision_helper.py").read_text() == ("# vision helper\n")
+
+    def test_skips_existing_file_by_default(self, agent_project: Path) -> None:
+        existing = agent_project / "tools" / "vision_helper.py"
+        existing.write_text("# original\n")
+        spec = ModalitySpec(
+            name="vision",
+            description="Vision",
+            source_files=(SourceFile("tools/vision_helper.py", "# replacement\n"),),
+        )
+        result = apply_modality(agent_project, spec)
+        assert any("already exists" in s for s in result.skipped)
+        assert existing.read_text() == "# original\n"
+
+    def test_overwrites_when_skip_disabled(self, agent_project: Path) -> None:
+        existing = agent_project / "tools" / "vision_helper.py"
+        existing.write_text("# original\n")
+        spec = ModalitySpec(
+            name="vision",
+            description="Vision",
+            source_files=(
+                SourceFile(
+                    "tools/vision_helper.py",
+                    "# replacement\n",
+                    skip_if_exists=False,
+                ),
+            ),
+        )
+        result = apply_modality(agent_project, spec)
+        assert "Wrote tools/vision_helper.py" in result.actions
+        assert existing.read_text() == "# replacement\n"
+
+    def test_creates_intermediate_directories(self, agent_project: Path) -> None:
+        spec = ModalitySpec(
+            name="deep",
+            description="Deep",
+            source_files=(SourceFile("integrations/voice/stt.py", "# stt\n"),),
+        )
+        apply_modality(agent_project, spec)
+        assert (agent_project / "integrations" / "voice" / "stt.py").exists()
+
+
+# ---------------------------------------------------------------------------
+# apply_modality — pyproject extras
+# ---------------------------------------------------------------------------
+
+
+class TestPyprojectExtras:
+    def test_adds_new_extra(self, agent_project: Path) -> None:
+        spec = ModalitySpec(
+            name="files",
+            description="File uploads",
+            pyproject_extra=PyprojectExtra(name="files", dependencies=("docling>=2.0",)),
+        )
+        result = apply_modality(agent_project, spec)
+        assert "Added [files] extra to pyproject.toml" in result.actions
+
+        text = (agent_project / "pyproject.toml").read_text()
+        assert 'files = ["docling>=2.0"]' in text or '"docling>=2.0"' in text
+
+    def test_merges_into_existing_extra(self, agent_project: Path) -> None:
+        spec = ModalitySpec(
+            name="metrics-plus",
+            description="Metrics plus",
+            pyproject_extra=PyprojectExtra(
+                name="metrics", dependencies=("opentelemetry-api>=1.20",)
+            ),
+        )
+        result = apply_modality(agent_project, spec)
+        assert "Updated [metrics] extra in pyproject.toml" in result.actions
+
+        text = (agent_project / "pyproject.toml").read_text()
+        # Pre-existing dep preserved, new dep added
+        assert "prometheus-client" in text
+        assert "opentelemetry-api" in text
+
+    def test_idempotent_when_dep_already_present(self, agent_project: Path) -> None:
+        spec = ModalitySpec(
+            name="metrics-noop",
+            description="Metrics noop",
+            pyproject_extra=PyprojectExtra(
+                name="metrics", dependencies=("prometheus-client>=0.20",)
+            ),
+        )
+        result = apply_modality(agent_project, spec)
+        assert any("already declares all deps" in s for s in result.skipped)
+
+
+# ---------------------------------------------------------------------------
+# apply_modality — preconditions
+# ---------------------------------------------------------------------------
+
+
+class TestPreconditions:
+    def test_failing_precondition_raises_and_makes_no_changes(self, agent_project: Path) -> None:
+        def precondition(_root: Path) -> tuple[bool, str]:
+            return False, "vision must be enabled before video"
+
+        spec = ModalitySpec(
+            name="video",
+            description="Video preprocessing",
+            chart_values_enable="files.enabled",  # would mutate if it ran
+            precondition=precondition,
+        )
+        with pytest.raises(ModalityError, match="vision must be enabled"):
+            apply_modality(agent_project, spec)
+
+        # Project state is untouched
+        values = _yaml_load(agent_project / "chart" / "values.yaml")
+        assert values["files"]["enabled"] is False
+
+    def test_passing_precondition_lets_the_apply_run(self, agent_project: Path) -> None:
+        def precondition(_root: Path) -> tuple[bool, str]:
+            return True, ""
+
+        spec = ModalitySpec(
+            name="files",
+            description="Files",
+            chart_values_enable="files.enabled",
+            precondition=precondition,
+        )
+        apply_modality(agent_project, spec)
+        values = _yaml_load(agent_project / "chart" / "values.yaml")
+        assert values["files"]["enabled"] is True
+
+
+# ---------------------------------------------------------------------------
+# Integration — `fips-agents add code-executor` end-to-end
+# ---------------------------------------------------------------------------
+
+
+class TestAddCodeExecutorE2E:
+    def test_first_run_writes_tool_and_toggles_chart(
+        self, agent_project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(agent_project)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["add", "code-executor"])
+        assert result.exit_code == 0, result.output
+
+        assert (agent_project / "tools" / "code_executor.py").exists()
+        values = _yaml_load(agent_project / "chart" / "values.yaml")
+        assert values["sandbox"]["enabled"] is True
+        assert "Sandbox code execution added" in result.output
+
+    def test_second_run_is_idempotent(
+        self, agent_project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(agent_project)
+        runner = CliRunner()
+        runner.invoke(cli, ["add", "code-executor"])
+        result = runner.invoke(cli, ["add", "code-executor"])
+        assert result.exit_code == 0, result.output
+        assert "already exists" in result.output
+        assert "already true" in result.output
+
+    def test_errors_when_not_in_an_agent_project(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["add", "code-executor"])
+        assert result.exit_code == 1
+        assert "Not in an agent project" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Spec validation — the existing CODE_EXECUTOR_SPEC stays consistent
+# ---------------------------------------------------------------------------
+
+
+class TestCodeExecutorSpec:
+    def test_spec_has_expected_shape(self) -> None:
+        # Guard against accidental edits drifting the spec away from what
+        # the existing add code-executor implementation guarantees.
+        assert CODE_EXECUTOR_SPEC.name == "code-executor"
+        assert CODE_EXECUTOR_SPEC.chart_values_enable == "sandbox.enabled"
+        assert CODE_EXECUTOR_SPEC.agent_yaml_enable is None
+        assert CODE_EXECUTOR_SPEC.pyproject_extra is None
+        assert len(CODE_EXECUTOR_SPEC.source_files) == 1
+        assert CODE_EXECUTOR_SPEC.source_files[0].relative_path == "tools/code_executor.py"


### PR DESCRIPTION
## Summary

Introduces `tools/modality.py` — a declarative helper for `add` subcommands that wire optional capabilities into existing agent projects. A `ModalitySpec` describes what to toggle in `agent.yaml`, what to toggle in `chart/values.yaml`, what source files to drop in, and what extras to register in `pyproject.toml`; `apply_modality()` walks the spec idempotently and returns actions / warnings / skipped steps for the caller to display.

This is foundational work for #19, #20, #21, #22. The four modalities (files, vision, voice, video) will land as thin spec definitions in follow-up PRs once the agent-template ships the necessary commented-out sections.

## What changes

- **New `tools/modality.py`** — `ModalitySpec`, `SourceFile`, `PyprojectExtra`, `ModalityResult`, `ModalityError`, `apply_modality()`. Uses ruamel.yaml round-trip to preserve comments and `${VAR:-default}` substitutions, tomlkit for pyproject.toml edits.
- **`add code-executor` refactored onto the helper** as a proof-of-fit. Behavior is preserved — same toggle, same source file, same next-steps panel — but the brittle ``replace("enabled: false", "enabled: true", 1)`` becomes a structured YAML key set.
- **`tools/project.py` gains `find_agent_project_root()`** — promoted from a private helper in `commands/add.py`, and now also honors `.template-info`'s `template.type == \"agent\"` signal alongside the legacy `agent.yaml` presence check.
- **New `tests/fixtures/agent_project/`** — committed structural snapshot of the agent-template layout (subset). Mirrors the precedent from `tests/fixtures/middleware_template/` (#3) so tests run offline.
- **`ruamel.yaml>=0.18,<0.19`** added as a runtime dependency.

## Why a helper rather than four bespoke commands

Each of #19–22 is the same shape with different inputs (yaml path, chart path, optional source files, optional extras, optional precondition). A spec-driven helper keeps each future ``add`` subcommand to ~20 lines of glue. It also gives us a single, tested seam for behavior that ``add code-executor`` previously implemented ad-hoc.

The helper supports a ``precondition`` callable, which is how #22 (video) will refuse when vision isn't enabled.

## Test plan
- [x] 24 new tests in `tests/test_modality.py` covering yaml toggles (top-level + nested), idempotency, missing-section warnings, source-file drops with skip/overwrite semantics, pyproject extra add/merge/idempotent, preconditions, and the existing ``add code-executor`` end-to-end.
- [x] All 231 pre-existing tests still pass without modification.
- [x] Manual smoke test against a fresh fixture copy: first run flips toggles + writes the tool, second run reports skipped, third run from a non-agent directory exits 1 with a clear hint.
- [x] black + ruff clean.
- [ ] CI green on PR.

## Out of scope

- No new `add` subcommand ships in this PR. The four B1 modalities arrive in follow-up PRs once the agent-template-side scaffolding is reviewed and (where needed) extended.
- No companion changes to fips-agents/agent-template; the existing template's `sandbox:` block already supports `add code-executor`.