### PR TITLE
feat: Add `fips-agents add files` to enable file uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -574,7 +574,30 @@ All patch subcommands (except `check`) accept `--dry-run` to preview changes wit
 
 The `add` command group wires optional capabilities into existing agent projects created with `fips-agents create agent`.
 
-**Run these commands from within your agent project directory.** The CLI locates the project root by looking for `agent.yaml`.
+**Run these commands from within your agent project directory.** The CLI locates the project root by looking for `.template-info` (or `agent.yaml` for legacy projects).
+
+#### `add files`
+
+```bash
+fips-agents add files
+```
+
+Enables file upload + attachment support. Flips `server.files.enabled` in `agent.yaml` and `files.enabled` in `chart/values.yaml`. The agent template already ships the rest of the files surface (storage backends, optional S3 bytes backend, ClamAV virus-scanner sidecar, Docling PDF/text extraction, pgvector chunking) — this command only wires up the toggles.
+
+**What it does:**
+
+1. Sets `server.files.enabled: true` in `agent.yaml`
+2. Sets `files.enabled: true` in `chart/values.yaml`
+3. Prints next steps for installing the `[files]` extra, choosing a backend (`sqlite` / `postgres`), enabling ClamAV, and enabling persistence
+
+**Example:**
+
+```bash
+cd my-research-agent
+fips-agents add files
+pip install -e '.[files]'
+export FILES_BACKEND=sqlite
+```
 
 #### `add code-executor`
 
@@ -779,7 +802,7 @@ fips-agents-cli/
 │       ├── cli.py          # Main CLI application
 │       ├── version.py      # Version information
 │       ├── commands/       # CLI command implementations
-│       │   ├── add.py      # add code-executor (wire capabilities)
+│       │   ├── add.py      # add files / code-executor (wire capabilities)
 │       │   ├── create.py   # create mcp-server, agent, gateway, ui
 │       │   ├── generate.py # generate tool/resource/prompt/middleware
 │       │   ├── model_car.py # create model-car

--- a/src/fips_agents_cli/commands/add.py
+++ b/src/fips_agents_cli/commands/add.py
@@ -128,6 +128,42 @@ CODE_EXECUTOR_SPEC = ModalitySpec(
 )
 
 
+FILES_NEXT_STEPS = (
+    r"1. Install the \[files] extra (pulls in docling + python-magic):",
+    r"   [dim]pip install -e '.\[files]'[/dim]",
+    "",
+    "2. Choose a persistence backend by setting FILES_BACKEND:",
+    "   [bold]sqlite[/bold] (dev / single-replica)",
+    "     [dim]export FILES_BACKEND=sqlite[/dim]",
+    "   [bold]postgres[/bold] (production / multi-replica)",
+    "     [dim]export FILES_BACKEND=postgres[/dim]",
+    "     [dim]export DATABASE_URL=postgresql://...[/dim]",
+    "",
+    "3. (Optional) For multi-replica deployments use the S3 bytes backend:",
+    "   [dim]chart/values.yaml: files.bytesBackend.type=s3 + bucket/region/credentials[/dim]",
+    "",
+    "4. (Optional) Enable the ClamAV virus-scanner sidecar:",
+    "   [dim]chart/values.yaml: files.virusScanner.enabled=true[/dim]",
+    "",
+    "5. (Optional) Persist uploaded bytes across pod restarts (PVC):",
+    "   [dim]chart/values.yaml: files.persistence.enabled=true[/dim]",
+    "",
+    "6. Upload a file and reference it in chat completions:",
+    "   [dim]curl -F file=@doc.pdf $AGENT_URL/v1/files[/dim]",
+    "   The response carries a file_id; pass it on subsequent",
+    "   /v1/chat/completions requests via the file_ids field.",
+)
+
+
+FILES_SPEC = ModalitySpec(
+    name="files",
+    description="File upload and attachment support",
+    agent_yaml_enable="server.files.enabled",
+    chart_values_enable="files.enabled",
+    next_steps=FILES_NEXT_STEPS,
+)
+
+
 def _print_modality_result(spec: ModalitySpec, result: ModalityResult) -> None:
     """Render the per-action lines + the success panel for an applied spec."""
     for action in result.actions:
@@ -171,6 +207,28 @@ def add():
     pass
 
 
+def _run_modality(spec: ModalitySpec) -> None:
+    """Shared implementation for every `add <modality>` subcommand."""
+    try:
+        project_root = _resolve_agent_project_or_exit()
+        console.print(f"[green]Found project root:[/green] {project_root}")
+
+        try:
+            result = apply_modality(project_root, spec)
+        except ModalityError as e:
+            console.print(f"\n[red]Error:[/red] {e}")
+            sys.exit(1)
+
+        _print_modality_result(spec, result)
+
+    except KeyboardInterrupt:
+        console.print("\n[yellow]Operation cancelled.[/yellow]")
+        sys.exit(130)
+    except Exception as e:
+        console.print(f"\n[red]Error:[/red] {e}")
+        sys.exit(1)
+
+
 @add.command("code-executor")
 def code_executor_cmd():
     """Wire sandbox code execution into the current agent project.
@@ -184,21 +242,24 @@ def code_executor_cmd():
 
         fips-agents add code-executor
     """
-    try:
-        project_root = _resolve_agent_project_or_exit()
-        console.print(f"[green]Found project root:[/green] {project_root}")
+    _run_modality(CODE_EXECUTOR_SPEC)
 
-        try:
-            result = apply_modality(project_root, CODE_EXECUTOR_SPEC)
-        except ModalityError as e:
-            console.print(f"\n[red]Error:[/red] {e}")
-            sys.exit(1)
 
-        _print_modality_result(CODE_EXECUTOR_SPEC, result)
+@add.command("files")
+def files_cmd():
+    """Enable file upload + attachment support in the current agent project.
 
-    except KeyboardInterrupt:
-        console.print("\n[yellow]Operation cancelled.[/yellow]")
-        sys.exit(130)
-    except Exception as e:
-        console.print(f"\n[red]Error:[/red] {e}")
-        sys.exit(1)
+    Flips ``server.files.enabled`` in agent.yaml and ``files.enabled`` in
+    chart/values.yaml. The agent template already ships the rest of the
+    files surface (storage backends, S3, ClamAV sidecar, Docling parsing,
+    pgvector chunking) — this command only wires up the toggles. Follow
+    the printed next-steps to install the ``[files]`` extra and choose a
+    persistence backend.
+
+    Example:
+
+        cd my-research-agent
+
+        fips-agents add files
+    """
+    _run_modality(FILES_SPEC)

--- a/tests/test_modality.py
+++ b/tests/test_modality.py
@@ -10,7 +10,7 @@ from click.testing import CliRunner
 from ruamel.yaml import YAML
 
 from fips_agents_cli.cli import cli
-from fips_agents_cli.commands.add import CODE_EXECUTOR_SPEC
+from fips_agents_cli.commands.add import CODE_EXECUTOR_SPEC, FILES_SPEC
 from fips_agents_cli.tools.modality import (
     ModalityError,
     ModalitySpec,
@@ -353,7 +353,73 @@ class TestAddCodeExecutorE2E:
 
 
 # ---------------------------------------------------------------------------
-# Spec validation — the existing CODE_EXECUTOR_SPEC stays consistent
+# Integration — `fips-agents add files` end-to-end
+# ---------------------------------------------------------------------------
+
+
+class TestAddFilesE2E:
+    def test_first_run_flips_both_toggles(
+        self, agent_project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(agent_project)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["add", "files"])
+        assert result.exit_code == 0, result.output
+
+        agent_yaml = _yaml_load(agent_project / "agent.yaml")
+        assert agent_yaml["server"]["files"]["enabled"] is True
+
+        values = _yaml_load(agent_project / "chart" / "values.yaml")
+        assert values["files"]["enabled"] is True
+
+        assert "File upload and attachment support added" in result.output
+
+    def test_second_run_is_idempotent(
+        self, agent_project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(agent_project)
+        runner = CliRunner()
+        runner.invoke(cli, ["add", "files"])
+        result = runner.invoke(cli, ["add", "files"])
+        assert result.exit_code == 0, result.output
+        # Both toggles must report skipped on the second pass.
+        assert result.output.count("already true") >= 2
+
+    def test_does_not_touch_pyproject_extras(
+        self, agent_project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The agent template ships [files] = ["fipsagents[files]"] already;
+        # add files must not duplicate or rewrite it.
+        before = (agent_project / "pyproject.toml").read_text()
+        monkeypatch.chdir(agent_project)
+        runner = CliRunner()
+        runner.invoke(cli, ["add", "files"])
+        after = (agent_project / "pyproject.toml").read_text()
+        assert before == after
+
+    def test_does_not_touch_unrelated_yaml_sections(
+        self, agent_project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(agent_project)
+        runner = CliRunner()
+        runner.invoke(cli, ["add", "files"])
+
+        agent_yaml = _yaml_load(agent_project / "agent.yaml")
+        # Unrelated sections preserved
+        assert agent_yaml["model"]["name"] == "${MODEL_NAME:-meta-llama/Llama-3.3-70B-Instruct}"
+        assert agent_yaml["server"]["traces"]["enabled"] == "${TRACES_ENABLED:-false}"
+        assert agent_yaml["memory"]["backend"] == "${MEMORY_BACKEND:-}"
+
+        values = _yaml_load(agent_project / "chart" / "values.yaml")
+        # Sandbox toggle untouched
+        assert values["sandbox"]["enabled"] is False
+        # Sibling files knobs untouched
+        assert values["files"]["persistence"]["enabled"] is False
+        assert values["files"]["virusScanner"]["enabled"] is False
+
+
+# ---------------------------------------------------------------------------
+# Spec validation — public specs stay consistent
 # ---------------------------------------------------------------------------
 
 
@@ -367,3 +433,16 @@ class TestCodeExecutorSpec:
         assert CODE_EXECUTOR_SPEC.pyproject_extra is None
         assert len(CODE_EXECUTOR_SPEC.source_files) == 1
         assert CODE_EXECUTOR_SPEC.source_files[0].relative_path == "tools/code_executor.py"
+
+
+class TestFilesSpec:
+    def test_spec_has_expected_shape(self) -> None:
+        # add files relies on the agent template already shipping the
+        # [files] extra and the full files surface; the spec only flips
+        # the two enabled toggles.
+        assert FILES_SPEC.name == "files"
+        assert FILES_SPEC.agent_yaml_enable == "server.files.enabled"
+        assert FILES_SPEC.chart_values_enable == "files.enabled"
+        assert FILES_SPEC.source_files == ()
+        assert FILES_SPEC.pyproject_extra is None
+        assert FILES_SPEC.precondition is None


### PR DESCRIPTION
## Summary

Wires the file-upload + attachment surface into existing agent projects. Flips `server.files.enabled` in `agent.yaml` and `files.enabled` in `chart/values.yaml`; everything else (storage backends, optional S3 bytes, ClamAV sidecar, Docling, pgvector chunking) is already shipped by the agent template.

Closes #19.

## Why this is small

The original B1 framing assumed `add files` would inject a `files:` config block, ClamAV sidecar definition, docling dependency, and example tool wiring. After reviewing the live agent-template, every one of those is **already in the template** — the `[files]` extra exists as `fipsagents[files]`, the ClamAV sidecar template is already gated by `files.virusScanner.enabled`, agent.yaml carries the full `server.files.*` block. So the CLI's job collapses to two toggles plus a next-steps guide. Implementation is ~30 LOC of `ModalitySpec` on top of the helper from #37.

## What changes

- New `FILES_SPEC` in `commands/add.py`: toggles `server.files.enabled` (agent.yaml) and `files.enabled` (chart/values.yaml). No source files. No pyproject extra (template already declares it).
- New `fips-agents add files` Click command, plus a refactor extracting the per-command boilerplate (`find project root → apply_modality → render result`) into a private `_run_modality(spec)` helper so future B1 commands stay one-liners.
- README updated with an `add files` section and the project-tree comment.
- 5 new tests in `tests/test_modality.py` covering: both toggles flip, idempotency on the second pass, pyproject untouched, unrelated yaml sections untouched.

## Test plan
- [x] 5 new e2e tests passing alongside the existing 24 helper/`add code-executor` tests
- [x] Full suite at 260 passing (was 255)
- [x] black + ruff clean
- [x] Manual smoke test on a fixture copy: first run flips both toggles + prints next-steps panel; second run reports both as already-true; pyproject.toml unchanged across both runs
- [ ] CI green on PR