### PR TITLE
fix: Skip GitHub prompt in non-interactive shells (#40)

### DIFF
--- a/src/fips_agents_cli/commands/create.py
+++ b/src/fips_agents_cli/commands/create.py
@@ -317,7 +317,7 @@ def mcp_server(
         console.print("\n[yellow]⚠[/yellow] Operation cancelled by user")
         sys.exit(130)
     except Exception as e:
-        console.print(f"\n[red]✗[/red] Unexpected error: {e}")
+        console.print(f"\n[red]✗[/red] Unexpected error: {e!r}")
         sys.exit(1)
 
 
@@ -603,7 +603,7 @@ def agent(
         console.print("\n[yellow]⚠[/yellow] Operation cancelled by user")
         sys.exit(130)
     except Exception as e:
-        console.print(f"\n[red]✗[/red] Unexpected error: {e}")
+        console.print(f"\n[red]✗[/red] Unexpected error: {e!r}")
         sys.exit(1)
 
 
@@ -862,7 +862,7 @@ def workflow(
         console.print("\n[yellow]⚠[/yellow] Operation cancelled by user")
         sys.exit(130)
     except Exception as e:
-        console.print(f"\n[red]✗[/red] Unexpected error: {e}")
+        console.print(f"\n[red]✗[/red] Unexpected error: {e!r}")
         sys.exit(1)
 
 
@@ -1121,7 +1121,7 @@ def gateway(
         console.print("\n[yellow]⚠[/yellow] Operation cancelled by user")
         sys.exit(130)
     except Exception as e:
-        console.print(f"\n[red]✗[/red] Unexpected error: {e}")
+        console.print(f"\n[red]✗[/red] Unexpected error: {e!r}")
         sys.exit(1)
 
 
@@ -1380,7 +1380,7 @@ def ui(
         console.print("\n[yellow]⚠[/yellow] Operation cancelled by user")
         sys.exit(130)
     except Exception as e:
-        console.print(f"\n[red]✗[/red] Unexpected error: {e}")
+        console.print(f"\n[red]✗[/red] Unexpected error: {e!r}")
         sys.exit(1)
 
 
@@ -1637,7 +1637,7 @@ def sandbox(
         console.print("\n[yellow]⚠[/yellow] Operation cancelled by user")
         sys.exit(130)
     except Exception as e:
-        console.print(f"\n[red]✗[/red] Unexpected error: {e}")
+        console.print(f"\n[red]✗[/red] Unexpected error: {e!r}")
         sys.exit(1)
 
 
@@ -1677,9 +1677,26 @@ def _determine_github_mode(use_github: bool, use_local: bool, yes: bool) -> bool
         console.print("[dim]Mode: GitHub (--yes with gh available)[/dim]")
         return True
 
+    # No TTY available (CI, agent-driven shells, piped input): can't prompt.
+    # Default to local; users opt in to GitHub with --github or --yes.
+    if not sys.stdin.isatty():
+        console.print(
+            "[dim]Mode: Local only (non-interactive shell — pass --github or --yes "
+            "to create a GitHub repo)[/dim]"
+        )
+        return False
+
     # Interactive: prompt user
     console.print("[cyan]GitHub CLI detected and authenticated.[/cyan]")
-    return click.confirm("Create GitHub repository?", default=True)
+    try:
+        return click.confirm("Create GitHub repository?", default=True)
+    except click.exceptions.Abort:
+        # Stdin closed mid-prompt (isatty lied, or input ended). Fall back to local.
+        console.print(
+            "\n[dim]Mode: Local only (no input available — pass --github or --yes "
+            "to create a GitHub repo)[/dim]"
+        )
+        return False
 
 
 def _show_success_message(

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -978,3 +978,68 @@ class TestCreateUi:
         assert result.exit_code == 0
         assert "Successfully created chat UI project" in result.output
         assert "my-chat-ui" in result.output
+
+
+class TestDetermineGithubMode:
+    """Tests for _determine_github_mode helper.
+
+    Regression coverage for issue #40: non-TTY shells (CI, agent-driven) hung
+    on the `Create GitHub repository?` prompt and exited with an empty
+    `Unexpected error:` message.
+    """
+
+    def _call(self, **overrides):
+        from fips_agents_cli.commands.create import _determine_github_mode
+
+        kwargs = {"use_github": False, "use_local": False, "yes": False}
+        kwargs.update(overrides)
+        return _determine_github_mode(**kwargs)
+
+    def test_local_flag_short_circuits(self):
+        with patch("sys.stdin.isatty", return_value=False):
+            assert self._call(use_local=True) is False
+
+    def test_github_flag_short_circuits(self):
+        assert self._call(use_github=True) is True
+
+    @patch("fips_agents_cli.commands.create.is_gh_installed", return_value=False)
+    def test_falls_back_to_local_when_gh_missing(self, _mock_installed):
+        assert self._call() is False
+
+    @patch("fips_agents_cli.commands.create.is_gh_authenticated", return_value=False)
+    @patch("fips_agents_cli.commands.create.is_gh_installed", return_value=True)
+    def test_falls_back_to_local_when_gh_unauthenticated(self, *_mocks):
+        assert self._call() is False
+
+    @patch("fips_agents_cli.commands.create.is_gh_authenticated", return_value=True)
+    @patch("fips_agents_cli.commands.create.is_gh_installed", return_value=True)
+    def test_yes_flag_chooses_github_when_gh_available(self, *_mocks):
+        assert self._call(yes=True) is True
+
+    @patch("sys.stdin.isatty", return_value=False)
+    @patch("fips_agents_cli.commands.create.is_gh_authenticated", return_value=True)
+    @patch("fips_agents_cli.commands.create.is_gh_installed", return_value=True)
+    def test_non_tty_falls_back_to_local_without_prompting(self, *_mocks):
+        # The fix for issue #40: never prompt when stdin isn't a TTY.
+        with patch("click.confirm") as mock_confirm:
+            assert self._call() is False
+            mock_confirm.assert_not_called()
+
+    @patch("sys.stdin.isatty", return_value=True)
+    @patch("fips_agents_cli.commands.create.is_gh_authenticated", return_value=True)
+    @patch("fips_agents_cli.commands.create.is_gh_installed", return_value=True)
+    def test_tty_prompts_user(self, *_mocks):
+        with patch("click.confirm", return_value=True) as mock_confirm:
+            assert self._call() is True
+            mock_confirm.assert_called_once()
+
+    @patch("sys.stdin.isatty", return_value=True)
+    @patch("fips_agents_cli.commands.create.is_gh_authenticated", return_value=True)
+    @patch("fips_agents_cli.commands.create.is_gh_installed", return_value=True)
+    def test_tty_with_aborted_confirm_falls_back_to_local(self, *_mocks):
+        # Defensive: if the prompt aborts (e.g. closed stdin while isatty
+        # claimed otherwise), we should not crash with `Unexpected error:`.
+        import click as _click
+
+        with patch("click.confirm", side_effect=_click.exceptions.Abort()):
+            assert self._call() is False


### PR DESCRIPTION
## Summary

- `_determine_github_mode` now checks `sys.stdin.isatty()` before calling `click.confirm`; non-TTY shells (CI, agent-driven, `claude-code`, piped input) fall back to local mode with a one-line hint about `--github` / `--yes` instead of hanging on the prompt
- Wraps the confirm call in `try/except click.exceptions.Abort` as defense in depth for environments where `isatty()` returns true but stdin closes mid-prompt
- Six `Unexpected error: {e}` sites now use `{e!r}` so a future swallowed empty-message exception (like the original `click.Abort`) surfaces its type instead of going blank
- Adds `TestDetermineGithubMode` (8 cases) covering flag short-circuits, gh-missing/unauthenticated paths, `--yes`, the new non-TTY fallback, and aborted-confirm fallback

The fix lives in the shared helper, so all six `create` subcommands (`mcp-server`, `agent`, `gateway`, `ui`, `workflow`, `sandbox`) get the new behavior. Closes #40.

## Test plan

- [x] `pytest --no-cov` — 273 passed (8 new)
- [x] `black --check src tests` — clean
- [x] `ruff check src tests` — clean
- [x] Manual repro: `echo "" | fips-agents create gateway test-gateway --target-dir …` no longer hangs; logs `Mode: Local only (non-interactive shell — pass --github or --yes …)` and proceeds to scaffold the project. Same verified for `create ui`.